### PR TITLE
Promisify

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,46 +1,56 @@
 # trimperson
-TRIM API wrapper
+TRIM API wrapper. Uses the RSVP library for promises.
 
 ## Installation
 
 ```
-npm install --save mediasuitenz/trimperson#v1.0.0
+npm install --save mediasuitenz/trimperson
 ```
 
 ## Usage
 ### setup module:
 ```js
-var trim = require('trim')('http://path/to/trim/api', 'trim-api-security-token')
+
+var env = {
+  "token": "",
+  "url": "",
+  "mock": false,
+  "debug": true,
+  "developmentContainer": "",
+  "useDevelopmentContainer": false
+}
+
+var trim = require('trim')(env)
 ```
 
 
 ### use module:
 Get a single container
 ```
-trim.getContainer ("BC140111", function (err, data)) {
-
-}
+trim.getContainer ("BC140111")
+.then(data => {})
+.catch(err => {})
 ```
 
 
 Create a new container
 ```
-trim.createContainer (???, function (err, data)) {
-
-}
+trim.createContainer (???)
+.then(data => {})
+.catch(err => {})
 ```
 
 
 Create a new record
 ```
-trim.createRecord () {
-
-}
+trim.createRecord (???)
+.then(data => {})
+.catch(err => {})
 ```
 
 
 
-### Hilltop data
+### TRIM data
 
 Data returned from find looks like:
 ```json

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "debug": "^2.2.0",
     "request": "^2.61.0",
-    "request-debug": "^0.2.0"
+    "request-debug": "^0.2.0",
+    "rsvp": "^3.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "license": "",
   "dependencies": {
     "debug": "^2.2.0",
+    "ramda-extended": "^0.2.0",
     "request": "^2.61.0",
     "request-debug": "^0.2.0",
     "rsvp": "^3.1.0"

--- a/trim.development.js
+++ b/trim.development.js
@@ -1,20 +1,28 @@
 var assert = require('assert');
 var url, token;
 
-function createRecord (title, container, extension, fileData, callback) {
-  callback(null, {RecordNo: "13228764"})
+function createRecord (title, container, extension, fileData) {
+  return new Promise(function (resolve) {
+    return resolve({RecordNo: "13228764"})
+  })
 }
 
-function getDocument (trimId, callback) {
-  callback(null, null);
+function getDocument (trimId) {
+  return new Promise(function (resolve) {
+    return resolve('');
+  })
 }
 
-function getContainer (trimId, callback) {
-  return callback(null, require('./mock/getContainer.json'));
+function getContainer (trimId) {
+  return new Promise(function (resolve) {
+    return resolve(require('./mock/getContainer.json'));
+  })
 }
 
-function createContainer (folderName, privacy, parentFolder, callback) {
-  callback(null, {}); // dunno what this is supposed to be.
+function createContainer (folderName, privacy, parentFolder) {
+  return new Promise(function (resolve) {
+    return resolve({})  // dunno what this is supposed to be.
+  })
 }
 
 module.exports = function (apiUrl, apiToken) {

--- a/trim.production.js
+++ b/trim.production.js
@@ -2,6 +2,7 @@ var request = require('request');
 var assert = require('assert');
 var debug = require('debug')('trim');
 var RSVP = require('rsvp');
+var R = require('ramda-extended')
 var url;
 var token;
 
@@ -84,6 +85,7 @@ function getDocument (trimId) {
  */
 function getContainer (trimId) {
   return new Promise(function (resolve, reject) {
+    if (!trimId) return reject(new Error('Invalid TRIM container id: ' + trimId))
     var options = {
       url: url + '/GetContainer?trimid=' + trimId + '&securityToken=' + token,
       json: true
@@ -91,7 +93,9 @@ function getContainer (trimId) {
     debug('GET %s', options.url);
     request.get(options, function (err, res, responseBody) {
       // responseBody has containerNo, subContainers, and records
-      return (err) ? reject(err): resolve(responseBody);
+      if (err) return reject(err);
+      if (R.isNilOrEmptyObj(responseBody)) return reject(new Error('Could not find container: ' + trimId))
+      return resolve(responseBody);
     });
 
   })

--- a/trim.production.js
+++ b/trim.production.js
@@ -1,9 +1,11 @@
 var request = require('request');
 var assert = require('assert');
 var debug = require('debug')('trim');
+var RSVP = require('rsvp');
 var url;
 var token;
 
+const Promise = RSVP.Promise;
 
 /**
  * Define the callback from the `createRecord` method
@@ -18,46 +20,50 @@ var token;
  * @param {String} container
  * @param {String} extension
  * @param {String} fileData
- * @param {createRecordCallback} callback
+ * @return {Promise}
  */
-function createRecord (title, container, extension, fileData, callback) {
-  var options = {
-    url: url + '/AddRecordToTrim?securityToken=' + token,
-    method: 'post',
-    body: {
-      Title: title,
-      Container: container,
-      RecordExtension: extension,
-      Record: fileData
-    },
-    json: true
-  }
-  request(options, function (err, res, responseBody) {
-    if (err) return callback(err);
-
-    var trimRecordNo = responseBody.RecordNo;
-
-    if (!trimRecordNo) {
-      debug('Invalid response %j', responseBody);
-      return callback(new Error('Error uploading document to TRIM: Missing RecordNo response. ' + responseBody.message));
+function createRecord (title, container, extension, fileData) {
+  return new Promise(function (resolve, reject) {
+    var options = {
+      url: url + '/AddRecordToTrim?securityToken=' + token,
+      method: 'post',
+      body: {
+        Title: title,
+        Container: container,
+        RecordExtension: extension,
+        Record: fileData
+      },
+      json: true
     }
-    debug('Created record with recordNo %s', trimRecordNo);
-    return callback(null, trimRecordNo)
-  });
+    request(options, function (err, res, responseBody) {
+      if (err) return reject(err);
+
+      var trimRecordNo = responseBody.RecordNo;
+
+      if (!trimRecordNo) {
+        debug('Invalid response %j', responseBody);
+        return reject(new Error('Error uploading document to TRIM: Missing RecordNo response. ' + responseBody.message));
+      }
+      debug('Created record with recordNo %s', trimRecordNo);
+      return resolve(trimRecordNo)
+    });
+  })
 }
 
 
 /**
  * Get the actual document, not the TRIM record
  * @param trimId
- * @param callback
+ * @return {Promise}
  */
-function getDocument (trimId, callback) {
-  var options = {
-    url: url + '/get?id=' + trimId + '&securityToken=' + token
-  }
-  request.get(options, function (err, res, responseBody) {
-    callback(err, responseBody);
+function getDocument (trimId) {
+  return new Promise(function (resolve, reject) {
+    var options = {
+      url: url + '/get?id=' + trimId + '&securityToken=' + token
+    }
+    request.get(options, function (err, res, responseBody) {
+      return (err) ? reject(err): resolve(responseBody);
+    })
   })
 }
 
@@ -74,18 +80,21 @@ function getDocument (trimId, callback) {
 
 /**
  * @param trimId
- * @param {containerCallback}  callback
+ * @return {Promise}
  */
-function getContainer (trimId, callback) {
-  var options = {
-    url: url + '/GetContainer?trimid=' + trimId + '&securityToken=' + token,
-    json: true
-  };
-  debug('GET %s', options.url);
-  request.get(options, function (err, res, responseBody) {
-    // responseBody has containerNo, subContainers, and records
-    callback(err, responseBody);
-  });
+function getContainer (trimId) {
+  return new Promise(function (resolve, reject) {
+    var options = {
+      url: url + '/GetContainer?trimid=' + trimId + '&securityToken=' + token,
+      json: true
+    };
+    debug('GET %s', options.url);
+    request.get(options, function (err, res, responseBody) {
+      // responseBody has containerNo, subContainers, and records
+      return (err) ? reject(err): resolve(responseBody);
+    });
+
+  })
 }
 
 
@@ -94,22 +103,24 @@ function getContainer (trimId, callback) {
  * @param folderName
  * @param privacy
  * @param parentFolder
- * @param callback
+ * @return {Promise}
  */
-function createContainer (folderName, privacy, parentFolder, callback) {
-  var body = {
-    RecordNo: folderName,
-    Title: folderName,
-    Privacy: privacy,
-    ParentFolder: parentFolder
-  };
-  var options = {
-    url: url + '/CreateContainer?securityToken=' + token,
-    json: body
-  };
-  request.post(options, function (err, res, responseBody) {
-    callback(err, responseBody);
-  });
+function createContainer (folderName, privacy, parentFolder) {
+  return new Promise(function (resolve, reject) {
+    var body = {
+      RecordNo: folderName,
+      Title: folderName,
+      Privacy: privacy,
+      ParentFolder: parentFolder
+    };
+    var options = {
+      url: url + '/CreateContainer?securityToken=' + token,
+      json: body
+    };
+    request.post(options, function (err, res, responseBody) {
+      return (err) ? reject(err): resolve(responseBody);
+    });
+  })
 }
 
 /**


### PR DESCRIPTION
We are going to use RSVP on the backend instead of callbacks. I was considering Bluebird as a promises library, but Ember is using RSVP, and I think to start with, it's easiest to just have the same api in the front and backend. 

I'm updating trimperson to use promises, so that it compatible with `ramda-extended.rsvp`.