### PR TITLE
move from dev-dependencies to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
   "dependencies": {
     "debug": "^2.2.0",
     "request": "^2.61.0",
-    "request-debug": "^0.2.0"
+    "request-debug": "^0.2.0",
+    "ramda-extended": "^0.2.1"
   },
   "devDependencies": {
     "chai": "^3.4.0",
@@ -23,7 +24,6 @@
     "mocha-babel": "^3.0.0",
     "mocha-given": "^0.1.3",
     "nock": "^2.17.0",
-    "ramda-extended": "^0.2.1",
     "testem": "^0.9.8",
     "xyz": "^0.5.0"
   }


### PR DESCRIPTION
ramda-extended needs to not be a dev-dependency

will run a `npm run deploy:minor` after merge