### PR TITLE
Add privacy levels

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,0 +1,30 @@
+# v3.0.0
+Introduce better access control.
+
+## Creating Records
+- Change createRecord parameters to accept a data object in instead of a bunch of sequential parameters
+- createRecord will still accept sequential parameters for backwards compatibility
+- createRecord accepts new privacyLevel parameter
+- add createPrivateRecord
+- add createPublicRecord
+
+## Fetching Containers
+
+- add getPublicContainer
+
+## Creating containers
+
+- Change createContainer parameters to accept a data object instead of a bunch of sequential parameters
+- createContainer will still accept sequential parameters for backwards compatibility
+- createContainer accepts new privacyLevel parameter
+- Add createPublicContainer
+- Add createPrivateContainer
+
+## Error handling
+The requests now actually handle error responses instead of relying on consumers to
+parse and intuit the meaning of responses. A bunch of error conditions have been introduced
+that will return error values in the response callbacks.
+
+
+# v2.2.1
+Unrecorded.

--- a/README.md
+++ b/README.md
@@ -10,37 +10,14 @@ npm install --save mediasuitenz/trimperson#v1.0.0
 ## Usage
 ### setup module:
 ```js
-var trim = require('trim')('http://path/to/trim/api', 'trim-api-security-token')
+var trim = require('trim')({
+  url: 'http://path/to/trim/api',
+  token: 'trim-api-security-token'
+})
 ```
 
 
-### use module:
-Get a single container
-```
-trim.getContainer ("BC140111", function (err, data)) {
-
-}
-```
-
-
-Create a new container
-```
-trim.createContainer (???, function (err, data)) {
-
-}
-```
-
-
-Create a new record
-```
-trim.createRecord () {
-
-}
-```
-
-
-
-### Hilltop data
+### TRIM data
 
 Data returned from find looks like:
 ```json

--- a/index.js
+++ b/index.js
@@ -2,12 +2,7 @@
 module.exports = function (config) {
   var library = config.mock === false ?  // mock is on by default
       require('./trim.production') :
-      require('./trim.development');
+      require('./trim.development')
 
-  if (config.mock) {
-    console.log('TRIM adapter is loading mock data');
-  } else {
-    console.log('TRIM adapter is live');
-  }
-  return library(config.url, config.token, config.debug);
+  return library(config.url, config.token, config.debug)
 }

--- a/index.js
+++ b/index.js
@@ -4,5 +4,5 @@ module.exports = function (config) {
       require('./trim.production') :
       require('./trim.development')
 
-  return library(config.url, config.token, config.debug)
+  return library(config)
 }

--- a/package.json
+++ b/package.json
@@ -3,11 +3,15 @@
   "version": "2.2.1",
   "description": "TRIM API wrapper",
   "main": "index.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/mediasuitenz/trimperson.git"
+  },
   "scripts": {
     "deploy:patch": "npm run test && node_modules/.bin/xyz -i patch",
     "deploy:minor": "npm run test && node_modules/.bin/xyz -i minor",
     "deploy:major": "npm run test && node_modules/.bin/xyz -i major",
-    "test": "node_modules/.bin/mocha -u mocha-given --compilers js:mocha-babel specs.js",
+    "test": "node_modules/.bin/mocha -u mocha-given --compilers js:babel-core/register specs.js",
     "test:watch": "node_modules/.bin/testem"
   },
   "author": "Mediasuite NZ",
@@ -20,8 +24,8 @@
   },
   "devDependencies": {
     "chai": "^3.4.0",
-    "mocha": "^2.3.3",
-    "mocha-babel": "^3.0.0",
+    "mocha": "^2.4.5",
+    "mocha-babel": "^3.0.3",
     "mocha-given": "^0.1.3",
     "nock": "^2.17.0",
     "testem": "^0.9.8",

--- a/specs.js
+++ b/specs.js
@@ -399,7 +399,7 @@ describe('When using trimperson api', () => {
       })
     })
 
-    describe('If all no privacy is specified', () => {
+    describe('If no privacyLevel is specified', () => {
       var createContainerMock, dataReturn, errReturn, data
 
       Given(() => data = {
@@ -434,7 +434,7 @@ describe('When using trimperson api', () => {
       var createContainerMock, dataReturn, errReturn, data
 
       Given(() => data = {
-        folderName: INVALID_FOLDER_NAME
+        folderName: ''
       })
       Given(() => {
         createContainerMock = nock(mockURL)

--- a/specs.js
+++ b/specs.js
@@ -36,6 +36,7 @@ describe('When using v2.2.1 or less', () => {
     trim = require('./index')({
       url: mockURL,
       token: mockToken,
+      testing: true,
       mock: false
     })
   })
@@ -157,6 +158,7 @@ describe('When using trimperson api', () => {
     trim = require('./index')({
       url: mockURL,
       token: mockToken,
+      testing: true,
       mock: false
     })
   })

--- a/specs.js
+++ b/specs.js
@@ -160,6 +160,14 @@ describe('When using trimperson api', () => {
     done()
   })
 
+  Then('Unit test: isValidPrivacyLevel', (done) => {
+    expect(trim.isValidPrivacyLevel(trim.PRIVACY_LEVELS.PUBLIC)).to.equal(true)
+    expect(trim.isValidPrivacyLevel(trim.PRIVACY_LEVELS.PRIVATE)).to.equal(true)
+    expect(trim.isValidPrivacyLevel(3)).to.equal(false)
+    done()
+  })
+
+
   /*
    CONSTANTS
    */

--- a/specs.js
+++ b/specs.js
@@ -18,10 +18,16 @@ describe('when using trimperson api', () => {
     })
   })
 
-  Then('it should have created a trimperson object', () => expect(trim).to.be.a('object'))
+  Then('it should have created a trimperson object', (done) => {
+    expect(trim).to.be.a('object')
+    done()
+  })
 
   describe('using the getContainer function', () => {
-    Then('the function should exist on the trim instance', () => expect(trim.getContainer).to.be.a('function'))
+    Then('the function should exist on the trim instance', (done) => {
+      expect(trim.getContainer).to.be.a('function')
+      done()
+    })
 
     describe('when invoking the getContainer funciton', () => {
       var getContainerMock
@@ -47,12 +53,13 @@ describe('when using trimperson api', () => {
         })
       })
 
-      Then('it should resolve without error', () => {
+      Then('it should resolve without error', (done) => {
         expect(errReturn).not.to.exist
         expect(dataReturn).to.exist
         expect(dataReturn.containerNo).to.equal('someid')
         expect(dataReturn.subContainers).to.be.a('array')
         getContainerMock.done() // throws an error if no request was recorded
+        done()
       })
     })
   })
@@ -79,10 +86,11 @@ describe('when using trimperson api', () => {
       })
     })
 
-    Then('it should getDocument succesfully', () => {
+    Then('it should getDocument succesfully', (done) => {
       expect(errReturn).not.to.exist
       expect(dataReturn).to.exist
       getDocumentMock.done()
+      done()
     })
   })
 
@@ -112,10 +120,11 @@ describe('when using trimperson api', () => {
         done()
       })
     })
-    Then('it should be able to create a container', () => {
+    Then('it should be able to create a container', (done) => {
       expect(errReturn).not.to.exist
       expect(dataReturn).to.exist
       createContainerMock.done()
+      done()
     })
   })
 
@@ -147,12 +156,13 @@ describe('when using trimperson api', () => {
           done()
         })
       })
-      Then('it should be able to succesfully use the function', () => {
+      Then('it should be able to succesfully use the function', (done) => {
         expect(errReturn).not.to.exist
         expect(dataReturn).to.exist
         expect(dataReturn).to.be.a('string')
         expect(dataReturn).to.equal('123456')
         createRecordMock.done()
+        done()
       })
 
     })
@@ -162,7 +172,7 @@ describe('when using trimperson api', () => {
       var dataReturn
       Given(() => {
         createRecordMock = nock(mockURL)
-          .filteringRequestBody(function (bodyt) {
+          .filteringRequestBody(function (body) {
             return '*'
           })
           .post('/AddRecordToTrim', '*')
@@ -176,10 +186,11 @@ describe('when using trimperson api', () => {
           done()
         })
       })
-      Then('it should fail when TRIM responds without a record number number', () => {
+      Then('it should fail when TRIM responds without a record number number', (done) => {
         expect(errReturn).to.exist
         expect(dataReturn).not.to.exist
         createRecordMock.done()
+        done()
       })
     })
   })

--- a/specs.js
+++ b/specs.js
@@ -162,7 +162,7 @@ describe('When using trimperson api', () => {
   })
 
   Then('it should have created a trimperson object', (done) => {
-    expect(trim).to.be.a('object')
+    expect(trim).to.be.an('object')
     done()
   })
 
@@ -179,7 +179,7 @@ describe('When using trimperson api', () => {
    */
   describe('Privacy constants should be available', () => {
     Then('`PRIVACY_LEVELS` should exist', (done) => {
-      expect(trim.PRIVACY_LEVELS).to.be.a('object')
+      expect(trim.PRIVACY_LEVELS).to.be.an('object')
       done()
     })
     Then('`PRIVACY_LEVELS` should have the correct PUBLIC value', (done) => {
@@ -390,7 +390,7 @@ describe('When using trimperson api', () => {
       })
       Then('The container is created', done => {
         expect(errReturn).not.to.exist
-        expect(dataReturn).to.be.a('object')
+        expect(dataReturn).to.be.an('object')
         expect(dataReturn.RecordNo).to.equal(VALID_FOLDER_NAME)
         createContainerMock.done()
         done()
@@ -421,7 +421,7 @@ describe('When using trimperson api', () => {
       })
       Then('The container is created', done => {
         expect(errReturn).not.to.exist
-        expect(dataReturn).to.be.a('object')
+        expect(dataReturn).to.be.an('object')
         expect(dataReturn.RecordNo).to.equal(VALID_FOLDER_NAME)
         createContainerMock.done()
         done()
@@ -667,7 +667,7 @@ describe('When using trimperson api', () => {
 
       Then('It should return the container', (done) => {
         expect(errReturn).not.to.exist
-        expect(dataReturn).to.be.a('object')
+        expect(dataReturn).to.be.an('object')
         expect(dataReturn.containerNo).to.equal('someid')
         expect(dataReturn.subContainers).to.be.a('array')
         getContainerMock.done()

--- a/specs.js
+++ b/specs.js
@@ -8,6 +8,9 @@ var R = require('ramda-extended')
 var VALID_TITLE = 'Some Title'
 var INVALID_TITLE = null
 
+var VALID_RECORD_NO = 'SomeRecordNo'
+var INVALID_RECORD_NO = ''
+
 var VALID_EXTENSION = 'pdf'
 var INVALID_EXTENSION = '.pdf'
 
@@ -18,7 +21,10 @@ var VALID_CONTAINER = 'oijsdoi'
 var INVALID_CONTAINER = null
 
 var VALID_FILEDATA = 'R0lGOD lhCwAOAMQfAP////7+/vj4+Hh4eHd3d/v7+/Dw8HV1dfLy8ubm5vX19e3t7fr'
-var INVALID_FILEDATA = 'R0lGOD lhCwAOAMQfAP////7+/vj4+Hh4eHd3d/v7+/Dw8HV1dfLy8ubm5vX19e3t7fr'
+var INVALID_FILEDATA = ''
+
+var VALID_FOLDER_NAME = 'Some folder'
+var INVALID_FOLDER_NAME = ''
 
 describe('When using v2.2.1 or less', () => {
   var trim, mockURL, mockToken
@@ -50,7 +56,7 @@ describe('When using v2.2.1 or less', () => {
           .filteringRequestBody(R.always('*'))
           .post('/AddRecordToTrim', '*')
           .query({securityToken: mockToken})
-          .reply(201, {RecordNo: '123456'})
+          .reply(201, {RecordNo: VALID_RECORD_NO})
     })
     When((done) => {
       trim.createRecord(title, containerId, extensionType, fileData, alternativeContainers, function (err, data) {
@@ -63,7 +69,7 @@ describe('When using v2.2.1 or less', () => {
       expect(errReturn).not.to.exist
       expect(dataReturn).to.exist
       expect(dataReturn).to.be.a('string')
-      expect(dataReturn).to.equal('123456')
+      expect(dataReturn).to.equal(VALID_RECORD_NO)
       createRecordMock.done()
       done()
     })
@@ -73,7 +79,7 @@ describe('When using v2.2.1 or less', () => {
   describe('You should be able to call `createRecord` with 4 arguments (no alternativeContainers)', () => {
     var title, containerId, extensionType, fileData, createRecordMock
 
-    Given(() => title = 'inside-out')
+    Given(() => title = VALID_FOLDER_NAME)
     Given(() => containerId = 'asdfjk')
     Given(() => extensionType = '.mp4')
     Given(() => fileData = 'R0lGOD lhCwAOAMQfAP////7+/vj4+Hh4eHd3d/v7+/Dw8HV1dfLy8ubm5vX19e3t7fr')
@@ -85,7 +91,7 @@ describe('When using v2.2.1 or less', () => {
           .filteringRequestBody(R.always('*'))
           .post('/AddRecordToTrim', '*')
           .query({securityToken: mockToken})
-          .reply(201, {RecordNo: '123456'})
+          .reply(201, {RecordNo: VALID_RECORD_NO})
     })
     When((done) => {
       trim.createRecord(title, containerId, extensionType, fileData, function (err, data) {
@@ -98,7 +104,7 @@ describe('When using v2.2.1 or less', () => {
       expect(errReturn).not.to.exist
       expect(dataReturn).to.exist
       expect(dataReturn).to.be.a('string')
-      expect(dataReturn).to.equal('123456')
+      expect(dataReturn).to.equal(VALID_RECORD_NO)
       createRecordMock.done()
       done()
     })
@@ -110,16 +116,16 @@ describe('When using v2.2.1 or less', () => {
     var dataReturn
     var errReturn
 
-    Given(() => folder = 'someFolder')
+    Given(() => folder = VALID_FOLDER_NAME)
     Given(() => parentFolder = 'someParentFolder')
-    Given(() => privacySetting = 'jamesBond')
+    Given(() => privacySetting = trim.PRIVACY_LEVELS.PUBLIC)
     Given(() => {
       createContainerMock = nock(mockURL)
           .filteringRequestBody(R.always('*'))
           .post('/CreateContainer', '*')
           .query({securityToken: mockToken})
           .reply(201, {
-            msg: 'create response' // TODO determine the shape of the response
+            RecordNo: VALID_FOLDER_NAME
           })
     })
     When((done) => {
@@ -342,20 +348,207 @@ describe('When using trimperson api', () => {
     })
   })
 
-      describe('When the request succeeds', () => {
-        Then('It should return the container', (done) => {
-          throw new Error('Not implemented')
+  /*
+   CREATE CONTAINER
+   */
+  describe('To create a container', () => {
+    Then('`createContainer` should be a function', (done) => {
+      expect(trim.createContainer).to.be.a('function')
+      done()
+    })
+    Then('`createPublicContainer` should be a function', (done) => {
+      expect(trim.createPublicContainer).to.be.a('function')
+      done()
+    })
+    Then('`createPrivateContainer` should be a function', (done) => {
+      expect(trim.createPrivateContainer).to.be.a('function')
+      done()
+    })
+
+    describe('If all inputs are valid', () => {
+      var createContainerMock, dataReturn, errReturn, data
+
+      Given(() => data = {
+        folderName: VALID_FOLDER_NAME,
+        privacyLevel: trim.PRIVACY_LEVELS.PUBLIC
+      })
+      Given(() => {
+        createContainerMock = nock(mockURL)
+            .filteringRequestBody(R.always('*'))
+            .post('/CreateContainer', '*')
+            .query({securityToken: mockToken})
+            .reply(201, {
+              RecordNo: VALID_FOLDER_NAME
+            })
+      })
+      When(done => {
+        trim.createContainer(data, (err, body) => {
+          errReturn = err
+          dataReturn = body
           done()
         })
       })
-      describe('When the request fails', () => {
-        Then('It should fail gracefully', (done) => {
-          throw new Error('Not implemented')
-          done()
-        })
+      Then('The container is created', done => {
+        expect(errReturn).not.to.exist
+        expect(dataReturn).to.be.a('object')
+        expect(dataReturn.RecordNo).to.equal(VALID_FOLDER_NAME)
+        createContainerMock.done()
+        done()
       })
     })
 
+    describe('If all no privacy is specified', () => {
+      var createContainerMock, dataReturn, errReturn, data
+
+      Given(() => data = {
+        folderName: VALID_FOLDER_NAME
+      })
+      Given(() => {
+        createContainerMock = nock(mockURL)
+            .filteringRequestBody(R.always('*'))
+            .post('/CreateContainer', '*')
+            .query({securityToken: mockToken})
+            .reply(201, {
+              RecordNo: VALID_FOLDER_NAME
+            })
+      })
+      When(done => {
+        trim.createContainer(data, (err, body) => {
+          errReturn = err
+          dataReturn = body
+          done()
+        })
+      })
+      Then('The container is created', done => {
+        expect(errReturn).not.to.exist
+        expect(dataReturn).to.be.a('object')
+        expect(dataReturn.RecordNo).to.equal(VALID_FOLDER_NAME)
+        createContainerMock.done()
+        done()
+      })
+    })
+
+    describe('No folder name is provided', () => {
+      var createContainerMock, dataReturn, errReturn, data
+
+      Given(() => data = {
+        folderName: INVALID_FOLDER_NAME
+      })
+      Given(() => {
+        createContainerMock = nock(mockURL)
+            .filteringRequestBody(R.always('*'))
+            .post('/CreateContainer', '*')
+            .query({securityToken: mockToken})
+            .reply(500, {
+              RecordNo: null
+            })
+      })
+      When(done => {
+        trim.createContainer(data, (err, body) => {
+          errReturn = err
+          dataReturn = body
+          done()
+        })
+      })
+      Then('The container is not created', done => {
+        expect(errReturn).to.exist
+        expect(dataReturn).not.to.exist
+        createContainerMock.done()
+        done()
+      })
+    })
+
+    describe('With escalated permissions and an invalid token', () => {
+      var createContainerMock, dataReturn, errReturn, data
+
+      Given(() => data = {
+        folderName: VALID_FOLDER_NAME,
+        privacyLevel: trim.PRIVACY_LEVELS.PUBLIC
+      })
+      Given(() => {
+        createContainerMock = nock(mockURL)
+            .filteringRequestBody(R.always('*'))
+            .post('/CreateContainer', '*')
+            .query({securityToken: mockToken})
+            .reply(401, {
+              message: 'Authorization has been denied for this request.'
+            })
+      })
+      When(done => {
+        trim.createContainer(data, (err, body) => {
+          errReturn = err
+          dataReturn = body
+          done()
+        })
+      })
+      Then('An error is returned', done => {
+        expect(errReturn).to.exist
+        expect(dataReturn).not.to.exist
+        createContainerMock.done()
+        done()
+      })
+    })
+
+    describe('A null `RecordNo` is returned', () => {
+      var createContainerMock, dataReturn, errReturn, data
+
+      Given(() => data = {
+        folderName: VALID_FOLDER_NAME,
+        privacyLevel: trim.PRIVACY_LEVELS.PUBLIC
+      })
+      Given(() => {
+        createContainerMock = nock(mockURL)
+            .filteringRequestBody(R.always('*'))
+            .post('/CreateContainer', '*')
+            .query({securityToken: mockToken})
+            .reply(201, {
+              RecordNo: null
+            })
+      })
+      When(done => {
+        trim.createContainer(data, (err, body) => {
+          errReturn = err
+          dataReturn = body
+          done()
+        })
+      })
+      Then('An error is returned', done => {
+        expect(errReturn).to.exist
+        expect(dataReturn).not.to.exist
+        createContainerMock.done()
+        done()
+      })
+    })
+
+    describe('The container already exists', () => {
+      var createContainerMock, dataReturn, errReturn, data
+
+      Given(() => data = {
+        folderName: VALID_FOLDER_NAME,
+        privacyLevel: trim.PRIVACY_LEVELS.PUBLIC
+      })
+      Given(() => {
+        createContainerMock = nock(mockURL)
+            .filteringRequestBody(R.always('*'))
+            .post('/CreateContainer', '*')
+            .query({securityToken: mockToken})
+            .reply(204)
+      })
+      When(done => {
+        trim.createContainer(data, (err, body) => {
+          errReturn = err
+          dataReturn = body
+          done()
+        })
+      })
+      Then('An error is returned', done => {
+        expect(errReturn).not.to.exist
+        expect(dataReturn).to.exist
+        expect(dataReturn.RecordNo).to.equal(VALID_FOLDER_NAME)
+        createContainerMock.done()
+        done()
+      })
+    })
   })
 
   /*
@@ -508,75 +701,5 @@ describe('When using trimperson api', () => {
       })
     })
 
-  })
-
-  describe('when using the createContainer function', () => {
-    var createContainerMock, folder, parentFolder, privacySetting
-    var dataReturn
-    var errReturn
-
-    Given(() => folder = 'someFolder')
-    Given(() => parentFolder = 'someParentFolder')
-    Given(() => privacySetting = 'jamesBond')
-    Given(() => {
-      createContainerMock = nock(mockURL)
-          .filteringRequestBody(R.always('*'))
-          .post('/CreateContainer', '*')
-          .query({securityToken: mockToken})
-          .reply(201, {
-            msg: 'create response' // TODO determine the shape of the response
-          })
-    })
-    When((done) => {
-      trim.createContainer(folder, privacySetting, parentFolder, function (err, data) {
-        errReturn = err
-        dataReturn = data
-        done()
-      })
-    })
-    Then('it should be able to create a container', (done) => {
-      expect(errReturn).not.to.exist
-      expect(dataReturn).to.exist
-      createContainerMock.done()
-      done()
-    })
-  })
-
-  describe('when using the createRecord function', () => {
-    var title, containerId, extensionType, alternativeContainers, fileData
-
-    Given(() => title = 'inside-out')
-    Given(() => containerId = 'asdfjk')
-    Given(() => extensionType = '.mp4')
-    Given(() => alternativeContainers = ['himark'])
-    Given(() => fileData = 'R0lGOD lhCwAOAMQfAP////7+/vj4+Hh4eHd3d/v7+/Dw8HV1dfLy8ubm5vX19e3t7fr')
-
-    describe('when the backend accepts the record', () => {
-    })
-
-    describe('when the TRIM fails to recieve a createRecord request', () => {
-      var errReturn
-      var dataReturn
-      Given(() => {
-        createRecordMock = nock(mockURL)
-            .filteringRequestBody(R.always('*'))
-            .post('/AddRecordToTrim', '*')
-            .query({securityToken: mockToken})
-            .reply(500, {msg: 'it failed'})
-      })
-      When((done) => {
-        trim.createRecord(title, containerId, extensionType, fileData, alternativeContainers, function (err, data) {
-          errReturn = err
-          dataReturn = data
-          done()
-        })
-      })
-      Then('it should fail when TRIM responds without a record number number', (done) => {
-        expect(errReturn).to.exist
-        expect(dataReturn).not.to.exist
-        createRecordMock.done()
-        done()
-      })
-    })
   })
 })

--- a/specs.js
+++ b/specs.js
@@ -145,6 +145,24 @@ describe('When using trimperson api', () => {
   })
 
   /*
+  CONSTANTS
+   */
+  describe('Privacy constants should be available', () => {
+    Then('`PRIVACY_LEVELS` should exist', (done) => {
+      expect(trim.PRIVACY_LEVELS).to.be.a('object')
+      done()
+    })
+    Then('`PRIVACY_LEVELS` should have the correct PUBLIC value', (done) => {
+      expect(trim.PRIVACY_LEVELS.PUBLIC).to.equal(1)
+      done()
+    })
+    Then('`PRIVACY_LEVELS` should have the correct PRIVATE value', (done) => {
+      expect(trim.PRIVACY_LEVELS.PRIVATE).to.equal(2)
+      done()
+    })
+  })
+
+  /*
   CREATE RECORD
    */
   describe('To create a record', () => {

--- a/specs.js
+++ b/specs.js
@@ -1,8 +1,129 @@
 /* global Given, Then, describe */
 var expect = require('chai').expect
 var nock = require('nock')
+var R = require('ramda-extended')
 
-describe('when using trimperson api', () => {
+
+describe('When using v2.2.1 or less', () => {
+  var trim, mockURL, mockToken
+
+  Given(() => mockURL = 'http://localhost')
+  Given(() => mockToken = 'DEADBEEF')
+
+  Given(() => {
+    trim = require('./index')({
+      url: mockURL,
+      token: mockToken,
+      mock: false
+    })
+  })
+
+  describe('You should be able to call `createRecord` with 5 arguments (include alternativeContainers)', () => {
+    var title, containerId, extensionType, fileData, alternativeContainers, createRecordMock
+
+    Given(() => title = 'inside-out')
+    Given(() => containerId = 'asdfjk')
+    Given(() => extensionType = '.mp4')
+    Given(() => alternativeContainers = ['himark'])
+    Given(() => fileData = 'R0lGOD lhCwAOAMQfAP////7+/vj4+Hh4eHd3d/v7+/Dw8HV1dfLy8ubm5vX19e3t7fr')
+
+    var errReturn
+    var dataReturn
+    Given(() => {
+      createRecordMock = nock(mockURL)
+          .filteringRequestBody(R.always('*'))
+          .post('/AddRecordToTrim', '*')
+          .query({securityToken: mockToken})
+          .reply(201, {RecordNo: '123456'})
+    })
+    When((done) => {
+      trim.createRecord(title, containerId, extensionType, fileData, alternativeContainers, function (err, data) {
+        errReturn = err
+        dataReturn = data
+        done()
+      })
+    })
+    Then('it should be able to successfully use the function', (done) => {
+      expect(errReturn).not.to.exist
+      expect(dataReturn).to.exist
+      expect(dataReturn).to.be.a('string')
+      expect(dataReturn).to.equal('123456')
+      createRecordMock.done()
+      done()
+    })
+
+  })
+
+  describe('You should be able to call `createRecord` with 4 arguments (no alternativeContainers)', () => {
+    var title, containerId, extensionType, fileData, createRecordMock
+
+    Given(() => title = 'inside-out')
+    Given(() => containerId = 'asdfjk')
+    Given(() => extensionType = '.mp4')
+    Given(() => fileData = 'R0lGOD lhCwAOAMQfAP////7+/vj4+Hh4eHd3d/v7+/Dw8HV1dfLy8ubm5vX19e3t7fr')
+
+    var errReturn
+    var dataReturn
+    Given(() => {
+      createRecordMock = nock(mockURL)
+          .filteringRequestBody(R.always('*'))
+          .post('/AddRecordToTrim', '*')
+          .query({securityToken: mockToken})
+          .reply(201, {RecordNo: '123456'})
+    })
+    When((done) => {
+      trim.createRecord(title, containerId, extensionType, fileData, function (err, data) {
+        errReturn = err
+        dataReturn = data
+        done()
+      })
+    })
+    Then('it should be able to successfully use the function', (done) => {
+      expect(errReturn).not.to.exist
+      expect(dataReturn).to.exist
+      expect(dataReturn).to.be.a('string')
+      expect(dataReturn).to.equal('123456')
+      createRecordMock.done()
+      done()
+    })
+
+  })
+
+  describe('You should be able to call `createContainer` with 4 arguments (no alternativeContainers)', () => {
+    var createContainerMock, folder, parentFolder, privacySetting
+    var dataReturn
+    var errReturn
+
+    Given(() => folder = 'someFolder')
+    Given(() => parentFolder = 'someParentFolder')
+    Given(() => privacySetting = 'jamesBond')
+    Given(() => {
+      createContainerMock = nock(mockURL)
+          .filteringRequestBody(R.always('*'))
+          .post('/CreateContainer', '*')
+          .query({securityToken: mockToken})
+          .reply(201, {
+            msg: 'create response' // TODO determine the shape of the response
+          })
+    })
+    When((done) => {
+      trim.createContainer(folder, privacySetting, parentFolder, function (err, data) {
+        errReturn = err
+        dataReturn = data
+        done()
+      })
+    })
+    Then('it should be able to successfully use the function', (done) => {
+      expect(errReturn).not.to.exist
+      expect(dataReturn).to.exist
+      createContainerMock.done()
+      done()
+    })
+  })
+
+})
+
+describe('When using trimperson api', () => {
   var trim
   var mockURL
   var mockToken
@@ -23,13 +144,247 @@ describe('when using trimperson api', () => {
     done()
   })
 
-  describe('using the getContainer function', () => {
-    Then('the function should exist on the trim instance', (done) => {
-      expect(trim.getContainer).to.be.a('function')
+  /*
+  CREATE RECORD
+   */
+  describe('To create a record', () => {
+    describe('Using the createRecord function', () => {
+      Then('createRecord should be a function', (done) => {
+        expect(trim.createRecord).to.be.a('function')
+        done()
+      })
+
+      describe('When the request succeeds', () => {
+        Then('It should return the container', (done) => {
+          throw new Error('Not implemented')
+          done()
+        })
+      })
+      describe('When the request fails', () => {
+        Then('It should fail gracefully', (done) => {
+          throw new Error('Not implemented')
+          done()
+        })
+      })
+
+    })
+
+    describe('Using the createPublicRecord function', () => {
+      Then('createPublicRecord should be a function', (done) => {
+        expect(trim.createPublicRecord).to.be.a('function')
+        done()
+      })
+      describe('When the request succeeds', () => {
+        Then('It should return the container', (done) => {
+          throw new Error('Not implemented')
+          done()
+        })
+      })
+      describe('When the request fails', () => {
+        Then('It should fail gracefully', (done) => {
+          throw new Error('Not implemented')
+          done()
+        })
+      })
+    })
+
+    describe('Using the createPrivateRecord function', () => {
+      Then('createPrivateRecord should be a function', (done) => {
+        expect(trim.createPrivateRecord).to.be.a('function')
+        done()
+      })
+      describe('When the request succeeds', () => {
+        Then('It should return the container', (done) => {
+          throw new Error('Not implemented')
+          done()
+        })
+      })
+      describe('When the request fails', () => {
+        Then('It should fail gracefully', (done) => {
+          throw new Error('Not implemented')
+          done()
+        })
+      })
+    })
+  })
+
+  /*
+  GET RECORD
+   */
+  describe('To get a single record', () => {
+    Then('`getDocument` should be a function', (done) => {
+      expect(trim.getDocument).to.be.a('function')
       done()
     })
 
-    describe('when invoking the getContainer funciton', () => {
+    describe('When the record exists', () => {
+      var documentId
+      var getDocumentMock
+      var dataReturn
+      var errReturn
+
+      Given(() => documentId = 'someIDthatPointsToADocument')
+      Given(() => {
+        getDocumentMock = nock(mockURL)
+            .get('/get')
+            .query({id: documentId, securityToken: mockToken})
+            .reply(200, 'R0lGOD lhCwAOAMQfAP////7+/vj4+Hh4eHd3d/v7+/Dw8')
+      })
+
+      When((done) => {
+        trim.getDocument(documentId, function (err, data) {
+          dataReturn = data
+          errReturn = err
+          done()
+        })
+      })
+
+      Then('It should return a document', (done) => {
+        expect(errReturn).not.to.exist
+        expect(dataReturn).to.exist
+        getDocumentMock.done()
+        done()
+      })
+    })
+    describe('When the record doesnt exist', () => {
+      Then('It should fail gracefully', (done) => {
+        throw new Error('What happens when we cant find a record')
+        done()
+      })
+    })
+  })
+
+  /*
+  CREATE CONTAINER
+   */
+  describe('To create a container', () => {
+    describe('Using the createContainer function', () => {
+      Then('createContainer should be a function', (done) => {
+        expect(trim.createContainer).to.be.a('function')
+        done()
+      })
+      describe('When the request succeeds', () => {
+        Then('It should return the container', (done) => {
+          throw new Error('Not implemented')
+          done()
+        })
+      })
+      describe('When the request fails', () => {
+        Then('It should fail gracefully', (done) => {
+          throw new Error('Not implemented')
+          done()
+        })
+      })
+
+    })
+
+    describe('Using the createPublicContainer function', () => {
+      Then('createPublicContainer should be a function', (done) => {
+        expect(trim.createPublicContainer).to.be.a('function')
+        done()
+      })
+      describe('When the request succeeds', () => {
+        Then('It should return the container', (done) => {
+          throw new Error('Not implemented')
+          done()
+        })
+      })
+      describe('When the request fails', () => {
+        Then('It should fail gracefully', (done) => {
+          throw new Error('Not implemented')
+          done()
+        })
+      })
+    })
+
+    describe('Using the createPrivateContainer function', () => {
+      Then('createPrivateContainer should be a function', (done) => {
+        expect(trim.createPrivateContainer).to.be.a('function')
+        done()
+      })
+      describe('When the request succeeds', () => {
+        Then('It should return the container', (done) => {
+          throw new Error('Not implemented')
+          done()
+        })
+      })
+      describe('When the request fails', () => {
+        Then('It should fail gracefully', (done) => {
+          throw new Error('Not implemented')
+          done()
+        })
+      })
+    })
+
+  })
+
+  /*
+  GET CONTAINER
+   */
+  describe('To get a container', () => {
+    describe('Using the `getContainer` function', () => {
+      Then('`getContainer` should be a function', (done) => {
+        expect(trim.getContainer).to.be.a('function')
+        done()
+      })
+
+      describe('When the container exists', () => {
+        Then('It should return the container', (done) => {
+          throw new Error('Not implemented')
+          done()
+        })
+      })
+      describe('When the container doesnt exist', () => {
+        Then('It should fail gracefully', (done) => {
+          throw new Error('Not implemented')
+          done()
+        })
+      })
+    })
+
+    describe('Using the `getPublicContainer` function', () => {
+      Then('`getPublicContainer` should be a function', (done) => {
+        expect(trim.getPublicContainer).to.be.a('function')
+        done()
+      })
+      describe('When the container exists', () => {
+        Then('It should return the container', (done) => {
+          throw new Error('Not implemented')
+          done()
+        })
+      })
+      describe('When the container doesnt exist', () => {
+        Then('It should fail gracefully', (done) => {
+          throw new Error('Not implemented')
+          done()
+        })
+      })
+    })
+
+    describe('Using the `getPrivateContainer` function', () => {
+      Then('`getPrivateContainer` should be a function', (done) => {
+        expect(trim.getPrivateContainer).to.be.a('function')
+        done()
+      })
+      describe('When the container exists', () => {
+        Then('It should return the container', (done) => {
+          throw new Error('Not implemented')
+          done()
+        })
+      })
+      describe('When the container doesnt exist', () => {
+        Then('It should fail gracefully', (done) => {
+          throw new Error('Not implemented')
+          done()
+        })
+      })
+    })
+
+  })
+
+  describe('using the `getContainer` function', () => {
+
+    describe('when invoking the `getContainer` funciton', () => {
       var getContainerMock
       var fakeID = 'fakecontainerid'
       var dataReturn
@@ -37,12 +392,12 @@ describe('when using trimperson api', () => {
 
       Given(() => {
         getContainerMock = nock(mockURL)
-          .get('/GetContainer')
-          .query({trimid: fakeID, securityToken: mockToken})
-          .reply(200, {
-            containerNo: 'someid',
-            subContainers: []
-          })
+            .get('/GetContainer')
+            .query({trimid: fakeID, securityToken: mockToken})
+            .reply(200, {
+              containerNo: 'someid',
+              subContainers: []
+            })
       })
 
       When((done) => {
@@ -64,36 +419,6 @@ describe('when using trimperson api', () => {
     })
   })
 
-  describe('when using the getDocument function', () => {
-    var documentId
-    var getDocumentMock
-    var dataReturn
-    var errReturn
-
-    Given(() => documentId = 'someIDthatPointsToADocument')
-    Given(() => {
-      getDocumentMock = nock(mockURL)
-        .get('/get')
-        .query({id: documentId, securityToken: mockToken})
-        .reply(200, 'data:video/mp4;base64,R0lGOD lhCwAOAMQfAP////7+/vj4+Hh4eHd3d/v7+/Dw8')
-    })
-
-    When((done) => {
-      trim.getDocument(documentId, function (err, data) {
-        dataReturn = data
-        errReturn = err
-        done()
-      })
-    })
-
-    Then('it should getDocument succesfully', (done) => {
-      expect(errReturn).not.to.exist
-      expect(dataReturn).to.exist
-      getDocumentMock.done()
-      done()
-    })
-  })
-
   describe('when using the createContainer function', () => {
     var createContainerMock, folder, parentFolder, privacySetting
     var dataReturn
@@ -104,14 +429,12 @@ describe('when using trimperson api', () => {
     Given(() => privacySetting = 'jamesBond')
     Given(() => {
       createContainerMock = nock(mockURL)
-        .filteringRequestBody(function (body) {
-          return '*' // this allows us to ignore the contents of the post for this asertion
-        })
-        .post('/CreateContainer', '*')
-        .query({ securityToken: mockToken })
-        .reply(201, {
-          msg: 'create response' // TODO determine the shape of the response
-        })
+          .filteringRequestBody(R.always('*'))
+          .post('/CreateContainer', '*')
+          .query({securityToken: mockToken})
+          .reply(201, {
+            msg: 'create response' // TODO determine the shape of the response
+          })
     })
     When((done) => {
       trim.createContainer(folder, privacySetting, parentFolder, function (err, data) {
@@ -129,42 +452,15 @@ describe('when using trimperson api', () => {
   })
 
   describe('when using the createRecord function', () => {
-    var title, containerId, extensionType, fileData, alternativeContainers, createRecordMock
+    var title, containerId, extensionType, alternativeContainers, fileData
 
     Given(() => title = 'inside-out')
     Given(() => containerId = 'asdfjk')
     Given(() => extensionType = '.mp4')
     Given(() => alternativeContainers = ['himark'])
-    Given(() => fileData = 'data:video/mp4;base64,R0lGOD lhCwAOAMQfAP////7+/vj4+Hh4eHd3d/v7+/Dw8HV1dfLy8ubm5vX19e3t7fr')
+    Given(() => fileData = 'R0lGOD lhCwAOAMQfAP////7+/vj4+Hh4eHd3d/v7+/Dw8HV1dfLy8ubm5vX19e3t7fr')
 
     describe('when the backend accepts the record', () => {
-      var errReturn
-      var dataReturn
-      Given(() => {
-        createRecordMock = nock(mockURL)
-          .filteringRequestBody(function (bodyt) {
-            return '*'
-          })
-          .post('/AddRecordToTrim', '*')
-          .query({ securityToken: mockToken })
-          .reply(201, { RecordNo: '123456' })
-      })
-      When((done) => {
-        trim.createRecord(title, containerId, extensionType, fileData, alternativeContainers, function (err, data) {
-          errReturn = err
-          dataReturn = data
-          done()
-        })
-      })
-      Then('it should be able to succesfully use the function', (done) => {
-        expect(errReturn).not.to.exist
-        expect(dataReturn).to.exist
-        expect(dataReturn).to.be.a('string')
-        expect(dataReturn).to.equal('123456')
-        createRecordMock.done()
-        done()
-      })
-
     })
 
     describe('when the TRIM fails to recieve a createRecord request', () => {
@@ -172,12 +468,10 @@ describe('when using trimperson api', () => {
       var dataReturn
       Given(() => {
         createRecordMock = nock(mockURL)
-          .filteringRequestBody(function (body) {
-            return '*'
-          })
-          .post('/AddRecordToTrim', '*')
-          .query({ securityToken: mockToken })
-          .reply(500, { msg: 'it failed wtfomg' })
+            .filteringRequestBody(R.always('*'))
+            .post('/AddRecordToTrim', '*')
+            .query({securityToken: mockToken})
+            .reply(500, {msg: 'it failed'})
       })
       When((done) => {
         trim.createRecord(title, containerId, extensionType, fileData, alternativeContainers, function (err, data) {

--- a/specs.js
+++ b/specs.js
@@ -259,7 +259,7 @@ describe('When using trimperson api', () => {
             done()
           })
         })
-        Then('It should fail gracefully when TRIM responds without a record number number', (done) => {
+        Then('It should return an error', (done) => {
           expect(errReturn).to.exist
           expect(dataReturn).not.to.exist
           createRecordMock.done()
@@ -272,7 +272,7 @@ describe('When using trimperson api', () => {
   })
 
   /*
-  GET RECORD
+   GET RECORD
    */
   describe('To get a single record', () => {
     Then('`getDocument` should be a function', (done) => {
@@ -281,17 +281,14 @@ describe('When using trimperson api', () => {
     })
 
     describe('When the record exists', () => {
-      var documentId
-      var getDocumentMock
-      var dataReturn
-      var errReturn
+      var documentId, getDocumentMock, dataReturn, errReturn
 
       Given(() => documentId = 'someIDthatPointsToADocument')
       Given(() => {
         getDocumentMock = nock(mockURL)
             .get('/get')
             .query({id: documentId, securityToken: mockToken})
-            .reply(200, 'R0lGOD lhCwAOAMQfAP////7+/vj4+Hh4eHd3d/v7+/Dw8')
+            .reply(200, VALID_FILEDATA)
       })
 
       When((done) => {
@@ -304,67 +301,39 @@ describe('When using trimperson api', () => {
 
       Then('It should return a document', (done) => {
         expect(errReturn).not.to.exist
-        expect(dataReturn).to.exist
+        expect(dataReturn).to.equal(VALID_FILEDATA)
         getDocumentMock.done()
         done()
       })
     })
     describe('When the record doesnt exist', () => {
-      Then('It should fail gracefully', (done) => {
-        throw new Error('What happens when we cant find a record')
+      var documentId, getDocumentMock, dataReturn, errReturn
+
+      Given(() => documentId = 'someIDthatPointsToADocument')
+      Given(() => {
+        getDocumentMock = nock(mockURL)
+            .get('/get')
+            .query({id: documentId, securityToken: mockToken})
+            .reply(404, '')
+      })
+
+      When((done) => {
+        trim.getDocument(documentId, function (err, data) {
+          dataReturn = data
+          errReturn = err
+          done()
+        })
+      })
+
+      Then('It should return an error', (done) => {
+        expect(errReturn).to.exist
+        expect(dataReturn).not.to.exist
+        getDocumentMock.done()
         done()
       })
     })
   })
 
-  /*
-  CREATE CONTAINER
-   */
-  describe('To create a container', () => {
-    describe('Using the createContainer function', () => {
-      Then('createContainer should be a function', (done) => {
-        expect(trim.createContainer).to.be.a('function')
-        done()
-      })
-      describe('When the request succeeds', () => {
-        Then('It should return the container', (done) => {
-          throw new Error('Not implemented')
-          done()
-        })
-      })
-      describe('When the request fails', () => {
-        Then('It should fail gracefully', (done) => {
-          throw new Error('Not implemented')
-          done()
-        })
-      })
-
-    })
-
-    describe('Using the createPublicContainer function', () => {
-      Then('createPublicContainer should be a function', (done) => {
-        expect(trim.createPublicContainer).to.be.a('function')
-        done()
-      })
-      describe('When the request succeeds', () => {
-        Then('It should return the container', (done) => {
-          throw new Error('Not implemented')
-          done()
-        })
-      })
-      describe('When the request fails', () => {
-        Then('It should fail gracefully', (done) => {
-          throw new Error('Not implemented')
-          done()
-        })
-      })
-    })
-
-    describe('Using the createPrivateContainer function', () => {
-      Then('createPrivateContainer should be a function', (done) => {
-        expect(trim.createPrivateContainer).to.be.a('function')
-        done()
-      })
       describe('When the request succeeds', () => {
         Then('It should return the container', (done) => {
           throw new Error('Not implemented')

--- a/specs.js
+++ b/specs.js
@@ -203,14 +203,6 @@ describe('When using trimperson api', () => {
       expect(trim.createRecord).to.be.a('function')
       done()
     })
-    Then('`createPublicRecord` should be a function', (done) => {
-      expect(trim.createPublicRecord).to.be.a('function')
-      done()
-    })
-    Then('`createPrivateRecord` should be a function', (done) => {
-      expect(trim.createPrivateRecord).to.be.a('function')
-      done()
-    })
     describe('Using the `createRecord` function', () => {
 
       describe('When the request succeeds', () => {
@@ -356,14 +348,6 @@ describe('When using trimperson api', () => {
   describe('To create a container', () => {
     Then('`createContainer` should be a function', (done) => {
       expect(trim.createContainer).to.be.a('function')
-      done()
-    })
-    Then('`createPublicContainer` should be a function', (done) => {
-      expect(trim.createPublicContainer).to.be.a('function')
-      done()
-    })
-    Then('`createPrivateContainer` should be a function', (done) => {
-      expect(trim.createPrivateContainer).to.be.a('function')
       done()
     })
 
@@ -559,14 +543,6 @@ describe('When using trimperson api', () => {
   describe('To get a container', () => {
     Then('`getContainer` should be a function', (done) => {
       expect(trim.getContainer).to.be.a('function')
-      done()
-    })
-    Then('`getPublicContainer` should be a function', (done) => {
-      expect(trim.getPublicContainer).to.be.a('function')
-      done()
-    })
-    Then('`getPrivateContainer` should be a function', (done) => {
-      expect(trim.getPrivateContainer).to.be.a('function')
       done()
     })
 

--- a/specs.js
+++ b/specs.js
@@ -119,7 +119,7 @@ describe('When using v2.2.1 or less', () => {
 
     Given(() => folder = VALID_FOLDER_NAME)
     Given(() => parentFolder = 'someParentFolder')
-    Given(() => privacySetting = trim.PRIVACY_LEVELS.PUBLIC)
+    Given(() => privacySetting = trim.PRIVACY.PUBLIC)
     Given(() => {
       createContainerMock = nock(mockURL)
           .filteringRequestBody(R.always('*'))
@@ -169,8 +169,8 @@ describe('When using trimperson api', () => {
   })
 
   Then('Unit test: isValidPrivacyLevel', (done) => {
-    expect(trim.isValidPrivacyLevel(trim.PRIVACY_LEVELS.PUBLIC)).to.equal(true)
-    expect(trim.isValidPrivacyLevel(trim.PRIVACY_LEVELS.PRIVATE)).to.equal(true)
+    expect(trim.isValidPrivacyLevel(trim.PRIVACY.PUBLIC)).to.equal(true)
+    expect(trim.isValidPrivacyLevel(trim.PRIVACY.PRIVATE)).to.equal(true)
     expect(trim.isValidPrivacyLevel(3)).to.equal(false)
     done()
   })
@@ -181,15 +181,15 @@ describe('When using trimperson api', () => {
    */
   describe('Privacy constants should be available', () => {
     Then('`PRIVACY_LEVELS` should exist', (done) => {
-      expect(trim.PRIVACY_LEVELS).to.be.an('object')
+      expect(trim.PRIVACY).to.be.an('object')
       done()
     })
     Then('`PRIVACY_LEVELS` should have the correct PUBLIC value', (done) => {
-      expect(trim.PRIVACY_LEVELS.PUBLIC).to.equal(1)
+      expect(trim.PRIVACY.PUBLIC).to.equal(1)
       done()
     })
     Then('`PRIVACY_LEVELS` should have the correct PRIVATE value', (done) => {
-      expect(trim.PRIVACY_LEVELS.PRIVATE).to.equal(2)
+      expect(trim.PRIVACY.PRIVATE).to.equal(2)
       done()
     })
   })
@@ -213,7 +213,7 @@ describe('When using trimperson api', () => {
           extension: VALID_EXTENSION,
           fileData: VALID_FILEDATA,
           alternativeContainers: VALID_ALTERNATIVE_CONTAINERS,
-          privacyLevel: trim.PRIVACY_LEVELS.PUBLIC
+          privacyLevel: trim.PRIVACY.PUBLIC
         })
         Given(() => {
           createRecordMock = nock(mockURL)
@@ -251,7 +251,7 @@ describe('When using trimperson api', () => {
           extension: VALID_EXTENSION,
           fileData: VALID_FILEDATA,
           alternativeContainers: VALID_ALTERNATIVE_CONTAINERS,
-          privacyLevel: trim.PRIVACY_LEVELS.PUBLIC
+          privacyLevel: trim.PRIVACY.PUBLIC
         })
         Given(() => {
           createRecordMock = nock(mockURL)
@@ -356,7 +356,7 @@ describe('When using trimperson api', () => {
 
       Given(() => data = {
         folderName: VALID_FOLDER_NAME,
-        privacyLevel: trim.PRIVACY_LEVELS.PUBLIC
+        privacyLevel: trim.PRIVACY.PUBLIC
       })
       Given(() => {
         createContainerMock = nock(mockURL)
@@ -449,7 +449,7 @@ describe('When using trimperson api', () => {
 
       Given(() => data = {
         folderName: VALID_FOLDER_NAME,
-        privacyLevel: trim.PRIVACY_LEVELS.PUBLIC
+        privacyLevel: trim.PRIVACY.PUBLIC
       })
       Given(() => {
         createContainerMock = nock(mockURL)
@@ -480,7 +480,7 @@ describe('When using trimperson api', () => {
 
       Given(() => data = {
         folderName: VALID_FOLDER_NAME,
-        privacyLevel: trim.PRIVACY_LEVELS.PUBLIC
+        privacyLevel: trim.PRIVACY.PUBLIC
       })
       Given(() => {
         createContainerMock = nock(mockURL)
@@ -511,7 +511,7 @@ describe('When using trimperson api', () => {
 
       Given(() => data = {
         folderName: VALID_FOLDER_NAME,
-        privacyLevel: trim.PRIVACY_LEVELS.PUBLIC
+        privacyLevel: trim.PRIVACY.PUBLIC
       })
       Given(() => {
         createContainerMock = nock(mockURL)
@@ -555,7 +555,7 @@ describe('When using trimperson api', () => {
             .reply(200)
       })
       When(done => {
-        trim.getContainer(VALID_CONTAINER, trim.PRIVACY_LEVELS.PUBLIC, () => done())
+        trim.getContainer(VALID_CONTAINER, trim.PRIVACY.PUBLIC, () => done())
       })
       Then('`/getContainer` is called', done => {
         getContainerMock.done()
@@ -572,7 +572,7 @@ describe('When using trimperson api', () => {
             .reply(200)
       })
       When(done => {
-        trim.getContainer(VALID_CONTAINER, trim.PRIVACY_LEVELS.PRIVATE, () => done())
+        trim.getContainer(VALID_CONTAINER, trim.PRIVACY.PRIVATE, () => done())
       })
       Then('`/getPrivateContainer` is called', done => {
         getContainerMock.done()
@@ -608,7 +608,7 @@ describe('When using trimperson api', () => {
             })
       })
       When(done => {
-        trim.getContainer(VALID_CONTAINER, trim.PRIVACY_LEVELS.PRIVATE, (err, data) => {
+        trim.getContainer(VALID_CONTAINER, trim.PRIVACY.PRIVATE, (err, data) => {
           errReturn = err
           dataReturn = data
           done()
@@ -636,7 +636,7 @@ describe('When using trimperson api', () => {
       })
 
       When((done) => {
-        trim.getContainer(VALID_CONTAINER, trim.PRIVACY_LEVELS.PUBLIC, (err, data) => {
+        trim.getContainer(VALID_CONTAINER, trim.PRIVACY.PUBLIC, (err, data) => {
           dataReturn = data
           errReturn = err
           done()
@@ -664,7 +664,7 @@ describe('When using trimperson api', () => {
       })
 
       When((done) => {
-        trim.getContainer(VALID_CONTAINER, trim.PRIVACY_LEVELS.PUBLIC, (err, data) => {
+        trim.getContainer(VALID_CONTAINER, trim.PRIVACY.PUBLIC, (err, data) => {
           dataReturn = data
           errReturn = err
           done()

--- a/trim.production.js
+++ b/trim.production.js
@@ -4,6 +4,7 @@ var debug = require('debug')('trim')
 var R = require('ramda-extended')
 var url
 var token
+var testing
 
 var PRIVACY_LEVELS = {
   PUBLIC: 1,
@@ -11,6 +12,12 @@ var PRIVACY_LEVELS = {
 }
 
 var isValidPrivacyLevel = R.contains(R.__, R.values(PRIVACY_LEVELS))
+
+function deprecationWarning(warning) {
+  if (!testing) {
+    console.log('DEPRECATION WARNING: ', warning)
+  }
+}
 
 /**
  * Define the callback from the `createRecord` method
@@ -33,7 +40,7 @@ var isValidPrivacyLevel = R.contains(R.__, R.values(PRIVACY_LEVELS))
 function createRecord(data, callback) {
   if (arguments.length === 5) {
     // Compatibility with usage before the alternativeContainers parameter was added
-    debug('WARNING: The createRecord arguments have changed to accept a single data parameter instead of multiple')
+    deprecationWarning('The createRecord arguments have changed to accept a single data parameter instead of multiple')
     data = {
       title: arguments[0],
       container: arguments[1],
@@ -45,7 +52,7 @@ function createRecord(data, callback) {
     callback = arguments[4]
   } else if (arguments.length === 6) {
     // Compatibility with usage after the alternativeContainers parameter was added
-    debug('WARNING: The createRecord arguments have changed to accept a single data parameter instead of multiple')
+    deprecationWarning('The createRecord arguments have changed to accept a single data parameter instead of multiple')
     data = {
       title: arguments[0],
       container: arguments[1],

--- a/trim.production.js
+++ b/trim.production.js
@@ -248,19 +248,23 @@ function createPrivateContainer (data, callback) {
 
 /**
  *
- * @param {String} apiUrl Base TRIM url
- * @param {String} apiToken TRIM securityToken
- * @param {Boolean} debug If true, then require `request-debug`
+ * @param {Object} options configuration options
+ * @param {String} options.url Base TRIM url
+ * @param {String} options.token TRIM securityToken
+ * @param {Boolean} options.debug If true, then require `request-debug`
+ * @param {Boolean} options.testing Hide deprecation warnings
  * @return {{getContainer: getContainer, getDocument: getDocument, createContainer: createContainer, createRecord:
  *     createRecord}}
  */
-module.exports = function (apiUrl, apiToken, debug) {
-  assert(typeof apiUrl === 'string', 'Argument 1 to instantiate the TRIM wrapper must be a valid url.')
-  assert(typeof apiToken === 'string', 'Argument 2 to instantiate the TRIM wrapper must be a valid apiToken.')
+module.exports = function (options) {
 
-  url = apiUrl
-  token = apiToken
-  if (!!debug)
+  assert(typeof options.url === 'string', 'TRIM wrapper must have a valid `url` argument.')
+  assert(typeof options.token === 'string', 'TRIM wrapper must have a valid `token` argument.')
+
+  url = options.url
+  token = options.token
+  testing = options.testing
+  if (!!options.debug)
     require('request-debug')(request)
 
   return {

--- a/trim.production.js
+++ b/trim.production.js
@@ -10,6 +10,8 @@ var PRIVACY_LEVELS = {
   PRIVATE: 2
 }
 
+var isValidPrivacyLevel = R.contains(R.__, R.values(PRIVACY_LEVELS))
+
 /**
  * Define the callback from the `createRecord` method
  * @callback createRecordCallback
@@ -52,6 +54,9 @@ function createRecord(data, callback) {
       alternativeContainers: arguments[4]
     }
     callback = arguments[5]
+  }
+  if (data.privacyLevel != null && !isValidPrivacyLevel(data.privacyLevel)) {
+    return callback(new Error('Invalid privacy level: ' + data.privacyLevel))
   }
 
   var options = {
@@ -237,6 +242,7 @@ module.exports = function (apiUrl, apiToken, debug) {
 
   return {
     PRIVACY_LEVELS: PRIVACY_LEVELS,
+    isValidPrivacyLevel: isValidPrivacyLevel,
     getDocument: getDocument,
 
     createRecord: createRecord,

--- a/trim.production.js
+++ b/trim.production.js
@@ -6,12 +6,12 @@ var url
 var token
 var testing
 
-var PRIVACY_LEVELS = {
+var PRIVACY = {
   PUBLIC: 1,
   PRIVATE: 2
 }
 
-var isValidPrivacyLevel = R.contains(R.__, R.values(PRIVACY_LEVELS))
+var isValidPrivacyLevel = R.contains(R.__, R.values(PRIVACY))
 
 function deprecationWarning(warning) {
   if (!testing) {
@@ -75,7 +75,7 @@ function createRecord(data, callback) {
       RecordExtension: data.extension,
       AlternativeContainers: data.alternativeContainers || [],
       Record: data.fileData,
-      Privacy: data.privacyLevel || PRIVACY_LEVELS.PUBLIC
+      Privacy: data.privacyLevel || PRIVACY.PUBLIC
     },
     json: true
   }
@@ -155,14 +155,14 @@ function getContainerUsingMethod(method, trimId, callback) {
 function getContainer (trimId, privacyLevel, callback) {
   if (arguments.length === 2) {
     callback = privacyLevel
-    privacyLevel = PRIVACY_LEVELS.PUBLIC
+    privacyLevel = PRIVACY.PUBLIC
   }
   var method
   switch (privacyLevel) {
-    case PRIVACY_LEVELS.PUBLIC:
+    case PRIVACY.PUBLIC:
       method = 'GetContainer'
       break
-    case  PRIVACY_LEVELS.PRIVATE:
+    case  PRIVACY.PRIVATE:
       method = 'getPrivateContainer'
       break
     default:
@@ -173,7 +173,7 @@ function getContainer (trimId, privacyLevel, callback) {
 
 function getPrivateContainer (trimId, callback) {
   deprecationWarning('getPrivateContainer is deprecated. Use getContainer and pass a privacy level instead.')
-  return getContainer(trimId, PRIVACY_LEVELS.PRIVATE, callback)
+  return getContainer(trimId, PRIVACY.PRIVATE, callback)
 }
 
 
@@ -205,7 +205,7 @@ function createContainer (data, callback) {
   var body = {
     RecordNo: data.folderName,
     Title: data.title || data.folderName,
-    Privacy: data.privacyLevel || PRIVACY_LEVELS.PUBLIC,
+    Privacy: data.privacyLevel || PRIVACY.PUBLIC,
     ParentFolder: data.parentFolder
   }
   // parentFolder currently returns a 500 error
@@ -255,7 +255,7 @@ module.exports = function (options) {
     require('request-debug')(request)
 
   return {
-    PRIVACY_LEVELS: PRIVACY_LEVELS,
+    PRIVACY: PRIVACY,
     isValidPrivacyLevel: isValidPrivacyLevel,
 
     getDocument: getDocument,

--- a/trim.production.js
+++ b/trim.production.js
@@ -1,9 +1,9 @@
-var request = require('request');
-var assert = require('assert');
-var debug = require('debug')('trim');
-var R = require('ramda-extended');
-var url;
-var token;
+var request = require('request')
+var assert = require('assert')
+var debug = require('debug')('trim')
+var R = require('ramda-extended')
+var url
+var token
 
 var PRIVACY_LEVELS = {
   PUBLIC: 1,
@@ -25,7 +25,7 @@ var PRIVACY_LEVELS = {
  * @param {String}    data.extension Omit the period, e.g. "pdf" or "png" but not ".png"
  * @param {String}    data.fileData Base64 String without the prefix
  * @param {String[]}  data.alternativeContainers A list of additional TRIM containers to upload to
- * @param {Boolean}   data.privacyLevel public=1, private=2; higher numbers escalate privacy level
+ * @param {Boolean}   data.privacyLevel public=1, private=2 -- higher numbers escalate privacy level
  * @param {createRecordCallback}  callback
  */
 function createRecord(data, callback) {
@@ -100,7 +100,7 @@ function getDocument (trimId, callback) {
     url: url + '/get?id=' + trimId + '&securityToken=' + token
   }
   request.get(options, function (err, res, responseBody) {
-    callback(err, responseBody);
+    callback(err, responseBody)
   })
 }
 
@@ -124,11 +124,11 @@ function getContainerUsingMethod(method, trimId, callback) {
   var options = {
     url: url + '/' + method + '?trimid=' + trimId + '&securityToken=' + token,
     json: true
-  };
-  debug('GET %s', options.url);
+  }
+  debug('GET %s', options.url)
   request.get(options, function (err, res, responseBody) {
-    callback(err, responseBody);
-  });
+    callback(err, responseBody)
+  })
 }
 
 /**
@@ -189,14 +189,15 @@ function createContainer (data, callback) {
     Title: data.folderName,
     Privacy: data.privacyLevel,
     ParentFolder: data.parentFolder
-  };
+  }
   var options = {
     url: url + '/CreateContainer?securityToken=' + token,
     json: body
-  };
+  }
+
   request.post(options, function (err, res, responseBody) {
     callback(err, responseBody)
-  });
+  })
 }
 
 function createPublicContainer (data, callback) {
@@ -220,10 +221,10 @@ module.exports = function (apiUrl, apiToken, debug) {
   assert(typeof apiUrl === 'string', 'Argument 1 to instantiate the TRIM wrapper must be a valid url.')
   assert(typeof apiToken === 'string', 'Argument 2 to instantiate the TRIM wrapper must be a valid apiToken.')
 
-  url = apiUrl;
-  token = apiToken;
+  url = apiUrl
+  token = apiToken
   if (!!debug)
-    require('request-debug')(request);
+    require('request-debug')(request)
 
   return {
     PRIVACY_LEVELS: PRIVACY_LEVELS,

--- a/trim.production.js
+++ b/trim.production.js
@@ -100,6 +100,9 @@ function getDocument (trimId, callback) {
     url: url + '/get?id=' + trimId + '&securityToken=' + token
   }
   request.get(options, function (err, res, responseBody) {
+    if (res.statusCode === 404) {
+      return callback(new Error('Not found'))
+    }
     callback(err, responseBody)
   })
 }
@@ -127,7 +130,15 @@ function getContainerUsingMethod(method, trimId, callback) {
   }
   debug('GET %s', options.url)
   request.get(options, function (err, res, responseBody) {
-    callback(err, responseBody)
+    if (err) {
+      callback(err)
+    } else if (res.statusCode === 401) {
+      callback(new Error('Unauthorized'))
+    } else if (responseBody == null) {
+      callback(new Error('Not Found'))
+    } else {
+      callback(err, responseBody)
+    }
   })
 }
 
@@ -152,7 +163,6 @@ function getContainer (trimId, privacyLevel, callback) {
       method = 'getPrivateContainer'
       break
     default:
-        console.log('INVALID PRIVACY LEVEL')
       return callback(new Error('Invalid privacyLevel: ' + privacyLevel))
   }
   return getContainerUsingMethod(method, trimId, callback)

--- a/trim.production.js
+++ b/trim.production.js
@@ -93,15 +93,6 @@ function createRecord(data, callback) {
   })
 }
 
-function createPublicRecord(data, callback) {
-  return createRecord(R.merge(data, {privacyLevel: PRIVACY_LEVELS.PUBLIC}), callback)
-}
-
-function createPrivateRecord(data, callback) {
-  return createRecord(R.merge(data, {privacyLevel: PRIVACY_LEVELS.PRIVATE}), callback)
-}
-
-
 /**
  * Get the actual document, not the TRIM record
  * @param trimId
@@ -180,11 +171,8 @@ function getContainer (trimId, privacyLevel, callback) {
   return getContainerUsingMethod(method, trimId, callback)
 }
 
-function getPublicContainer (trimId, callback) {
-  return getContainer(trimId, PRIVACY_LEVELS.PUBLIC, callback)
-}
-
 function getPrivateContainer (trimId, callback) {
+  deprecationWarning('getPrivateContainer is deprecated. Use getContainer and pass a privacy level instead.')
   return getContainer(trimId, PRIVACY_LEVELS.PRIVATE, callback)
 }
 
@@ -245,14 +233,6 @@ function createContainer (data, callback) {
   })
 }
 
-function createPublicContainer (data, callback) {
-  return createContainer(R.merge(data, {privacyLevel: PRIVACY_LEVELS.PUBLIC}), callback)
-}
-
-function createPrivateContainer (data, callback) {
-  return createContainer(R.merge(data, {privacyLevel: PRIVACY_LEVELS.PRIVATE}), callback)
-}
-
 /**
  *
  * @param {Object} options configuration options
@@ -277,19 +257,15 @@ module.exports = function (options) {
   return {
     PRIVACY_LEVELS: PRIVACY_LEVELS,
     isValidPrivacyLevel: isValidPrivacyLevel,
-    getDocument: getDocument,
 
+    getDocument: getDocument,
     createRecord: createRecord,
-    createPublicRecord: createPublicRecord,
-    createPrivateRecord: createPrivateRecord,
 
     getContainer: getContainer,
-    getPublicContainer: getPublicContainer,
-    getPrivateContainer: getPrivateContainer,
-
     createContainer: createContainer,
-    createPublicContainer: createPublicContainer,
-    createPrivateContainer: createPrivateContainer
+
+    // deprecations
+    getPrivateContainer: getPrivateContainer
 
   }
 }

--- a/trim.production.js
+++ b/trim.production.js
@@ -31,27 +31,27 @@ var PRIVACY_LEVELS = {
 function createRecord(data, callback) {
   if (arguments.length === 5) {
     // Compatibility with usage before the alternativeContainers parameter was added
-    console.log('WARNING: The createRecord arguments have changed to accept a single data parameter instead of multiple')
+    debug('WARNING: The createRecord arguments have changed to accept a single data parameter instead of multiple')
     data = {
       title: arguments[0],
       container: arguments[1],
       extension: arguments[2],
       fileData: arguments[3],
       alternativeContainers: [],
-      callback: arguments[4],
       privacyLevel: 1
     }
+    callback = arguments[4]
   } else if (arguments.length === 6) {
     // Compatibility with usage after the alternativeContainers parameter was added
-    console.log('WARNING: The createRecord arguments have changed to accept a single data parameter instead of multiple')
+    debug('WARNING: The createRecord arguments have changed to accept a single data parameter instead of multiple')
     data = {
       title: arguments[0],
       container: arguments[1],
       extension: arguments[2],
       fileData: arguments[3],
-      alternativeContainers: arguments[4],
-      callback: arguments[5]
+      alternativeContainers: arguments[4]
     }
+    callback = arguments[5]
   }
 
   var options = {
@@ -152,10 +152,10 @@ function getContainer (trimId, privacyLevel, callback) {
       method = 'getPrivateContainer'
       break
     default:
+        console.log('INVALID PRIVACY LEVEL')
       return callback(new Error('Invalid privacyLevel: ' + privacyLevel))
   }
-  return getContainerUsingMethod(method, trimId, token, callback)
-
+  return getContainerUsingMethod(method, trimId, callback)
 }
 
 function getPublicContainer (trimId, callback) {
@@ -180,9 +180,9 @@ function createContainer (data, callback) {
     data = {
       folderName: arguments[0],
       privacyLevel: arguments[1],
-      parentFolder: arguments[2],
-      callback: arguments[3]
+      parentFolder: arguments[2]
     }
+    callback = arguments[3]
   }
   var body = {
     RecordNo: data.folderName,
@@ -206,7 +206,6 @@ function createPublicContainer (data, callback) {
 
 function createPrivateContainer (data, callback) {
   return createContainer(R.merge(data, {privacyLevel: PRIVACY_LEVELS.PRIVATE}), callback)
-
 }
 
 /**

--- a/trim.production.js
+++ b/trim.production.js
@@ -166,27 +166,46 @@ function getPrivateContainer (trimId, callback) {
   return getContainer(trimId, PRIVACY_LEVELS.PRIVATE, callback)
 }
 
+
 /**
- *
- * @param folderName
- * @param privacy
- * @param parentFolder
- * @param callback
+ * @param {Object} data
+ * @param {String} data.folderName
+ * @param {Number} data.privacyLevel
+ * @param {String} data.parentFolder
+ * @param {???} callback
  */
-function createContainer (folderName, privacy, parentFolder, callback) {
+function createContainer (data, callback) {
+  if (arguments.length === 4) {
+    // Compatibility with old api
+    data = {
+      folderName: arguments[0],
+      privacyLevel: arguments[1],
+      parentFolder: arguments[2],
+      callback: arguments[3]
+    }
+  }
   var body = {
-    RecordNo: folderName,
-    Title: folderName,
-    Privacy: privacy,
-    ParentFolder: parentFolder
+    RecordNo: data.folderName,
+    Title: data.folderName,
+    Privacy: data.privacyLevel,
+    ParentFolder: data.parentFolder
   };
   var options = {
     url: url + '/CreateContainer?securityToken=' + token,
     json: body
   };
   request.post(options, function (err, res, responseBody) {
-    callback(err, responseBody);
+    callback(err, responseBody)
   });
+}
+
+function createPublicContainer (data, callback) {
+  return createContainer(R.merge(data, {privacyLevel: PRIVACY_LEVELS.PUBLIC}), callback)
+}
+
+function createPrivateContainer (data, callback) {
+  return createContainer(R.merge(data, {privacyLevel: PRIVACY_LEVELS.PRIVATE}), callback)
+
 }
 
 /**
@@ -209,7 +228,7 @@ module.exports = function (apiUrl, apiToken, debug) {
   return {
     PRIVACY_LEVELS: PRIVACY_LEVELS,
     getDocument: getDocument,
-    createContainer: createContainer,
+
     createRecord: createRecord,
     createPublicRecord: createPublicRecord,
     createPrivateRecord: createPrivateRecord,
@@ -217,6 +236,10 @@ module.exports = function (apiUrl, apiToken, debug) {
     getContainer: getContainer,
     getPublicContainer: getPublicContainer,
     getPrivateContainer: getPrivateContainer,
+
+    createContainer: createContainer,
+    createPublicContainer: createPublicContainer,
+    createPrivateContainer: createPrivateContainer
 
   }
 }


### PR DESCRIPTION
@markstuart @digitalsadhu @ebuckley @ewen @Resonance1584 - idk who else has their hands in this trim shenanigans

Motivation: To add access control support to document creation as well as container get/create

Note: This introduces some major breaking api changes. 

Creation methods now accept data objects instead of a bagillion positional parameters, but I added some hooks to intuit when you're using the old format. You will need to use the data objects to use the privacyLevel parameters. 

I also started to catch error responses from TRIM and return them as errors instead of leaving that up to the consumer. 

From the new changelog file:

Introduce better access control.

## Creating Records
- Change createRecord parameters to accept a data object in instead of a bunch of sequential parameters
- createRecord will still accept sequential parameters for backwards compatibility
- createRecord accepts new privacyLevel parameter
- add createPrivateRecord
- add createPublicRecord

## Fetching Containers

- add getPublicContainer

## Creating containers

- Change createContainer parameters to accept a data object instead of a bunch of sequential parameters
- createContainer will still accept sequential parameters for backwards compatibility
- createContainer accepts new privacyLevel parameter
- Add createPublicContainer
- Add createPrivateContainer

## Error handling
The requests now actually handle error responses instead of relying on consumers to
parse and intuit the meaning of responses. A bunch of error conditions have been introduced
that will return error values in the response callbacks.
